### PR TITLE
APP-62 first draft of pluraliser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+.eslintrc

--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,0 +1,6 @@
+check:
+  global:
+    statements: 100
+    lines: 100
+    branches: 100
+    functions: 100

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - "0.10"
+script:
+  - npm run ci
+cache:
+  directories:
+    - node_modules

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # pluralise
 Pluralise our product names
+
+We have a need to pluralise product names in a strange way at times, this repo covers those rules.
+
+## Usage
+```javascript
+  pluralise.plural('sheep') # returns 'sheep'
+```
+
+## Test
+```
+  npm test
+```
+
+## Lint
+uses https://github.com/holidayextras/make-up
+```
+  npm run lint
+```
+
+## Coverage
+expects 100% coverage (shouldn't be too hard)
+```
+  npm run coverage
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "pluralise",
+  "version": "1.0.0",
+  "description": "Pluralise our product names",
+  "main": "src/pluralize",
+  "scripts": {
+    "ci": "npm run lint && npm run coverage",
+    "coverage": "istanbul cover _mocha -- test/*.js && istanbul check-coverage",
+    "lint": "make-up src && echo '🍻  All good!'",
+    "test": "mocha"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/holidayextras/pluralise.git"
+  },
+  "author": "Paul Clarke <paul.clarke@holidayextras.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/holidayextras/pluralise/issues"
+  },
+  "homepage": "https://github.com/holidayextras/pluralise#readme",
+  "devDependencies": {
+    "chai": "^3.4.1",
+    "istanbul": "^0.4.1",
+    "make-up": "^6.0.0",
+    "mocha": "^2.3.4"
+  },
+  "dependencies": {
+    "pluralize": "^1.2.1"
+  }
+}

--- a/src/pluralize.js
+++ b/src/pluralize.js
@@ -1,0 +1,13 @@
+'use strict';
+var pluralize = require('pluralize');
+
+pluralize.addPluralRule('parking', 'carparks');
+
+pluralize.addPluralRule('hotel_with_parking', 'hotels');
+
+pluralize.addPluralRule('insurance', 'insurance');
+
+// we don't pluralise theatrebreaks for some reason
+pluralize.addPluralRule('theatrebreak', 'theatrebreak');
+
+module.exports = pluralize;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,33 @@
+'use strict';
+var pluralize = require('../src/pluralize');
+var expect = require('chai').expect;
+
+describe('pluralise', function() {
+  describe('parking', function() {
+    it('pluralises to the product name we need', function() {
+      expect(pluralize('parking')).to.equal('carparks');
+    });
+  });
+
+  describe('insurance', function() {
+    it('does not pluralise insurance', function() {
+      expect(pluralize('insurance')).to.equal('insurance');
+    });
+  });
+
+  describe('theatrebreak', function() {
+    it('does not pluralise as we do not use that name', function() {
+      expect(pluralize('theatrebreak')).to.equal('theatrebreak');
+    });
+  });
+
+  describe('hotels', function() {
+    it('pluralises to the product name we need', function() {
+      expect(pluralize('hotel')).to.equal('hotels');
+      expect(pluralize('hotel_with_parking')).to.equal('hotels');
+    });
+    it('does not double pluralise a plural', function() {
+      expect(pluralize('hotels')).to.equal('hotels');
+    });
+  });
+});


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

First draft at putting our pluralising rules in one place. Possibly overkill including the `pluralize` library for front end, but the principle would be the same if we got rid of that.

#### What tests does this PR have?

Unit tests in this pr in the usual place

#### How can this be tested?

`npm coverage`

it's not used anywhere yet but I'm planning on it going into the tripapp repo and wherever else it is needed.

---

- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

#### Reviewers

**Review 1**
- [ ] :+1:

**Review 2** \*
- [ ] :+1:

**Review 3** _(optional)_
- [ ] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

\*  for HX this review must be completed by an SE, SA or Project Guru